### PR TITLE
Fix jerky animations

### DIFF
--- a/data/model/hudgun/pulserifle/md5.cfg
+++ b/data/model/hudgun/pulserifle/md5.cfg
@@ -11,7 +11,7 @@ md5tag "X_pulse_base" "base"
 
 md5anim "mapmodel"  "model.md5anim"
 md5anim "gun idle"  "idle.md5anim"
-md5anim "gun shoot" "shoot.md5anim" 45
+md5anim "gun shoot" "shoot.md5anim" 60
 md5anim "gun melee" "melee.md5anim" 60
 
 md5pitch "" 1

--- a/data/model/hudgun/railgun/md5.cfg
+++ b/data/model/hudgun/railgun/md5.cfg
@@ -11,7 +11,7 @@ md5tag "X_rail_base" "base"
 
 md5anim "mapmodel"  "model.md5anim"
 md5anim "gun idle"  "idle.md5anim"
-md5anim "gun shoot" "shoot.md5anim" 23
+md5anim "gun shoot" "shoot.md5anim" 30
 md5anim "gun melee" "melee.md5anim" 60
 
 md5pitch "" 1


### PR DESCRIPTION
The pulse rifle and railgun animations are jerky due to animations not ending in time. This PR fixes that.