### PR TITLE
Raise the SMG

### DIFF
--- a/data/model/hudgun/smg/md5.cfg
+++ b/data/model/hudgun/smg/md5.cfg
@@ -36,4 +36,4 @@ md5link 0 1 "base"
 
 mdlyaw -90
 mdlspec 200
-mdltrans -2.980 -1.200 -2.600
+mdltrans -2.980 -1.200 -2.450


### PR DESCRIPTION
My recent edits to the SMG made it appear to be held lower than other weapons. This should raise it to about the height of a pulserifle.