### PR TITLE
Autocomplete for player names and case insensitive chat mentions

### DIFF
--- a/config/game.cfg
+++ b/config/game.cfg
@@ -303,12 +303,12 @@ copymapcfg = [
     ]
 ]
 
-chatsay  = [ inputcommand "" [ say $commandbuf ] "[Chat]" s ]
+chatsay  = [ inputcommand "" [ say $commandbuf ] "[Chat]" n ]
 chatteam = [
     if (|| $isspectator [= $getteam 0]) [
         chatsay
     ] [
-        inputcommand "" [sayteam $commandbuf] (+s "[" $getteamtextcode "Team Chat^f7]") s
+        inputcommand "" [sayteam $commandbuf] (+s "[" $getteamtextcode "Team Chat^f7]") n
     ]
 ]
 chatexec = [ inputcommand "" [ commandbuf ] "[^f4Console^f7]" s ]

--- a/source/engine/engine.h
+++ b/source/engine/engine.h
@@ -591,7 +591,7 @@ extern float renderconsole(float w, float h, float abovehud);
 extern void conoutf(const char *s, ...) PRINTFARGS(1, 2);
 extern void conoutf(int type, const char *s, ...) PRINTFARGS(2, 3);
 extern void resetcomplete();
-extern void complete(char *s, int maxlen, const char *cmdprefix);
+extern void complete(char *s, int maxlen, const char *cmdprefix, bool names = false);
 const char *getkeyname(int code);
 extern const char *addreleaseaction(char *s);
 extern tagval *addreleaseaction(ident *id, int numargs);

--- a/source/shared/igame.h
+++ b/source/shared/igame.h
@@ -129,6 +129,7 @@ namespace game
     extern const char *getclientmap();
     extern const char *getmapinfo();
     extern const char *getscreenshotinfo();
+    extern const char *completename(const char *start, int len, const char *last, const char *next);
 
     extern int numdynents(const int flags = DYN_PLAYER|DYN_AI);
     extern int scaletime(int t);


### PR DESCRIPTION
- Chat mentions are now case insensitive
- Underscores must be used in order to match a name that contains spaces
- Player names can be auto-completed by typing '@' in the command line and pressing TAB

Closes #111 